### PR TITLE
fix: add required name and description fields to agent configurations

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,4 +1,6 @@
 ---
+name: developer
+description: Python developer agent for implementing features and fixes in da_vinci packages. Use for feature development, bug fixes, and code modifications.
 model: sonnet
 skills:
   - development

--- a/.claude/agents/documentation.md
+++ b/.claude/agents/documentation.md
@@ -1,4 +1,6 @@
 ---
+name: documentation
+description: Documentation agent for maintaining accurate, objective documentation for da_vinci project. Use for docstring validation, documentation updates, and documentation audits.
 model: sonnet
 skills:
   - python-docs

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,4 +1,6 @@
 ---
+name: qa
+description: QA engineer agent for creating pytest tests and ensuring test coverage for da_vinci packages. Use for test creation and test coverage improvements.
 model: sonnet
 skills:
   - testing


### PR DESCRIPTION
## Summary
Added required `name` and `description` fields to agent configuration frontmatter for developer, documentation, and qa agents.

## Changes
- Added `name` field to developer agent configuration
- Added `description` field to developer agent configuration
- Added `name` field to documentation agent configuration
- Added `description` field to documentation agent configuration
- Added `name` field to qa agent configuration
- Added `description` field to qa agent configuration