### PR TITLE
Fix missing da-vinci package in Lambda base image

### DIFF
--- a/packages/cdk/da_vinci_cdk/application.py
+++ b/packages/cdk/da_vinci_cdk/application.py
@@ -248,7 +248,10 @@ class Application:
 
         self.root_domain_name = root_domain_name
 
+        import da_vinci
+
         self.lib_docker_image = DockerImage.from_build(
+            build_args={"DA_VINCI_VERSION": da_vinci.__version__},
             cache_disabled=disable_docker_image_cache,
             path=self.lib_container_entry,
         )
@@ -532,7 +535,10 @@ class SideCarApplication:
 
         self._stacks: dict[str, Any] = {}
 
+        import da_vinci
+
         self.lib_docker_image = DockerImage.from_build(
+            build_args={"DA_VINCI_VERSION": da_vinci.__version__},
             cache_disabled=disable_docker_image_cache,
             path=self.lib_container_entry,
         )

--- a/packages/core/da_vinci/Dockerfile
+++ b/packages/core/da_vinci/Dockerfile
@@ -1,5 +1,6 @@
 ARG IMAGE=public.ecr.aws/lambda/python:3.12
 FROM $IMAGE
+ARG DA_VINCI_VERSION
 
 # set the pip cache location
 ENV PIP_CACHE_DIR=/tmp/pip-cache
@@ -7,7 +8,7 @@ ENV PIP_CACHE_DIR=/tmp/pip-cache
 # Install system dependencies needed by da-vinci
 RUN dnf install -y gcc libxml2-devel libxslt-devel git && \
     rm -Rf /var/cache/yum && \
-    pip install --upgrade pip
+    pip install --upgrade pip uv
 
 ADD . ${LAMBDA_TASK_ROOT}/da_vinci
 RUN if [ -f ${LAMBDA_TASK_ROOT}/da_vinci/pyproject.toml ]; then \
@@ -16,5 +17,5 @@ RUN if [ -f ${LAMBDA_TASK_ROOT}/da_vinci/pyproject.toml ]; then \
         cd ${LAMBDA_TASK_ROOT}/da_vinci/ && \
         poetry install; \
     else \
-        pip install 'boto3>=1.37.13' 'requests>=2.32.3' 'requests-auth-aws-sigv4==0.7'; \
+        uv pip install --system --extra-index-url https://packages.davinciproject.dev/simple/ "da-vinci==${DA_VINCI_VERSION}"; \
     fi 

--- a/packages/core/tests/test_docker_build.py
+++ b/packages/core/tests/test_docker_build.py
@@ -1,0 +1,67 @@
+"""Integration tests for Docker image builds"""
+
+import docker
+import pytest
+
+
+def test_library_base_image_has_davinci():
+    """Test that da-vinci package is installed in the library base image"""
+    # Try common Docker socket locations
+    import os
+    from pathlib import Path
+
+    socket_paths = [
+        "unix:///var/run/docker.sock",  # Standard Linux
+        f"unix://{Path.home()}/.docker/run/docker.sock",  # Docker Desktop Mac
+        f"unix://{Path.home()}/.colima/default/docker.sock",  # Colima
+    ]
+
+    client = None
+    for socket in socket_paths:
+        try:
+            client = docker.DockerClient(base_url=socket)
+            client.ping()  # Test connection
+            break
+        except (docker.errors.DockerException, Exception):
+            continue
+
+    if not client:
+        pytest.skip("Docker is not available")
+
+    # Build the image
+    image, logs = client.images.build(
+        path="packages/core/da_vinci",
+        dockerfile="Dockerfile",
+        buildargs={"DA_VINCI_VERSION": "3.0.4"},
+        tag="test-davinci:latest",
+    )
+
+    # Test 1: da-vinci package is importable
+    result = client.containers.run(
+        "test-davinci:latest",
+        command="python -c 'import da_vinci; print(da_vinci.__version__)'",
+        entrypoint="",  # Override Lambda entrypoint
+        remove=True,
+    )
+    assert b"3.0.4" in result
+
+    # Test 2: requests is available
+    result = client.containers.run(
+        "test-davinci:latest",
+        command="python -c 'import requests; print(requests.__version__)'",
+        entrypoint="",  # Override Lambda entrypoint
+        remove=True,
+    )
+    assert result  # Should not error
+
+    # Test 3: Can import event bus client (the failing import)
+    result = client.containers.run(
+        "test-davinci:latest",
+        command="python -c 'from da_vinci.event_bus.client import EventResponder; print(\"OK\")'",
+        entrypoint="",  # Override Lambda entrypoint
+        remove=True,
+    )
+    assert b"OK" in result
+
+    # Cleanup
+    client.images.remove("test-davinci:latest", force=True)


### PR DESCRIPTION
## Summary
The Lambda base image Dockerfile now installs the da-vinci package from the private package index instead of only installing direct dependencies, fixing import errors for event bus functionality in production deployments.

## Changes
- Updated `packages/core/da_vinci/Dockerfile` to use `uv pip install` with da-vinci package from private index
- Added `DA_VINCI_VERSION` build arg to Dockerfile
- Modified `packages/cdk/da_vinci_cdk/application.py` to pass `DA_VINCI_VERSION` build arg when building Docker images
- Added `uv` to system dependencies in Dockerfile

## Tests Added
- `test_docker_build.py::test_library_base_image_has_davinci` - Validates da-vinci package is installed and importable in built image
- Verifies event bus client can be imported without errors
- Confirms package version matches expected version